### PR TITLE
Change the precision of date_obs and the types of some variables and define unique_dir

### DIFF
--- a/blackbox.py
+++ b/blackbox.py
@@ -101,6 +101,7 @@ def run_blackbox (telescope=None, mode=None, date=None, read_path=None, slack=No
     ref_ID_filt = Queue()
 
     if mode == 'day':
+
         # if in day mode, feed all bias, flat and science images (in
         # this order) to [blackbox_reduce] using multiprocessing
         filenames = sort_files(read_path, '*fits*')
@@ -117,6 +118,7 @@ def run_blackbox (telescope=None, mode=None, date=None, read_path=None, slack=No
                 result = blackbox_reduce(filename, telescope, mode, read_path)
 
         else:
+
             # use [pool_func] to process list of files
             result = pool_func (blackbox_reduce, filenames, telescope, mode, read_path)
 
@@ -271,6 +273,7 @@ def blackbox_reduce (filename, telescope, mode, read_path):
        for the gain and overscan to running ZOGY on the reduced image.
 
     """
+
     if get_par(set_zogy.timing,tel):
         t_blackbox_reduce = time.time()
 
@@ -292,7 +295,7 @@ def blackbox_reduce (filename, telescope, mode, read_path):
     # and determine the raw data path (which is not necessarily the
     # same as the input [read_path])
     raw_path, __ = get_path(header['DATE-OBS'], 'read')
-    
+
     if raw_path == read_path:
 
         if mode == 'night':
@@ -305,6 +308,7 @@ def blackbox_reduce (filename, telescope, mode, read_path):
                                   'the standard [raw_path] directory: {}'
                                   .format(raw_path)))
     else:
+
         # move the image to [raw_path] if it does not already exist
         src = filename
         dest = '{}/{}'.format(raw_path, filename.split('/')[-1])
@@ -1563,6 +1567,7 @@ def set_header(header, filename):
 
     # RA and DEC
     if 'RA' in header.keys() and 'DEC' in header.keys():
+
         # Right ascension
         if ':' in str(header['RA']):
             # convert sexagesimal to decimal degrees
@@ -1892,6 +1897,7 @@ def gain_corr(data, header):
 ################################################################################
 
 def get_path (date, dir_type):
+
     # define path
     if date is None:
         q.put(logger.critical('no [date] provided; exiting'))
@@ -1909,6 +1915,7 @@ def get_path (date, dir_type):
             else:
                 date_format = '%Y-%m-%dT%H:%M:%S'
                 high_noon = 'T12:00:00'
+
             date_ut = dt.datetime.strptime(date, date_format).replace(tzinfo=gettz('UTC'))
             date_noon = date.split('T')[0]+high_noon
             date_local_noon = dt.datetime.strptime(date_noon, date_format).replace(

--- a/blackbox.py
+++ b/blackbox.py
@@ -941,8 +941,7 @@ def sat_detect (data, header, data_mask, header_mask, tmp_path):
         #create satellite trail if found
         trail_coords = results[(fits_binned_mask,0)] 
         #continue if satellite trail found
-        if len(trail_coords) > 0:
-            unique_dir = tmp_path #Danielle: unique_dir wasn't defined. I think it's supposed to be the tmp_path, or isn't it? 
+        if len(trail_coords) > 0: 
             trail_segment = trail_coords[0]
             try: 
                 #create satellite trail mask
@@ -951,11 +950,11 @@ def sat_detect (data, header, data_mask, header_mask, tmp_path):
             except ValueError:
                 #if error occurs, add comment
                 print ('Warning: satellite trail found but could not be fitted for file {} and is not included in the mask.'
-                       .format(unique_dir.split('/')[-1]))
+                       .format(tmp_path.split('/')[-1]))
                 break
             satellite_fitting = True
             binned_data[mask_binned == 1] = np.median(binned_data)
-            fits_old_mask = unique_dir+'/old_mask.fits'
+            fits_old_mask = tmp_path+'/old_mask.fits'
             if os.path.isfile(fits_old_mask):
                 old_mask = read_hdulist(fits_old_mask, ext_data=0)
                 mask_binned = old_mask+mask_binned


### PR DESCRIPTION
1. We define the format of date_obs as %Y-%m-%dT%H:%M:%S.%f and as "%f" can only have 6 digits (microsecond precision) it gives an error for any date_obs value that has a higher precision (which occurs for our newest data taken in December / January). I added a line where date_obs is rounded to microseconds.

2. Had to change 2 variables to a string (RA and DEC when searching for the symbol ':' in their values) and one to a time (date_obs), or else errors occurred.

3. unique_dir wasn't defined. I think what is meant here is tmp_path, so I replaced unique_dir with tmp_path.

4. Removed some unnecessary comments