### PR TITLE
RA and DEC correction

### DIFF
--- a/blackbox.py
+++ b/blackbox.py
@@ -1051,14 +1051,14 @@ def make_dir(path, empty=False):
 
 ################################################################################
 
-def copy_files2keep (tmp_base, dest_base, ext2keep):
+def copy_files2keep (tmp_base, dest_base, ext2keep, move=True):
 
-    """Function to copy files with base name [tmp_base] and extensions
+    """Function to copy/move files with base name [tmp_base] and extensions
     [ext2keep] to files with base name [dest_base] with the same
     extensions. The base names should include the full path.
     """
     
-    lock.acquire()
+    #lock.acquire()
     # list of all files starting with [tmp_base]
     tmpfiles = glob.glob('{}*'.format(tmp_base))
     # loop this list
@@ -1072,10 +1072,14 @@ def copy_files2keep (tmp_base, dest_base, ext2keep):
                 # if so, and the source and destination names are not
                 # identical, go ahead and copy
                 if tmpfile != destfile:
-                    log.info('copying {} to {}'.format(tmpfile, destfile))
-                    shutil.copyfile(tmpfile, destfile)
+                    if not move:
+                        log.info('copying {} to {}'.format(tmpfile, destfile))
+                        shutil.copyfile(tmpfile, destfile)
+                    else:
+                        log.info('copying {} to {}'.format(tmpfile, destfile))
+                        shutil.move(tmpfile, destfile)
 
-    lock.release()
+    #lock.release()
     return
 
 
@@ -1588,18 +1592,17 @@ def set_header(header, filename):
         # subsequent image up to 9 Feb 2019 (except when put in by
         # hand with the sexagesimal notation, in which case keywords
         # RA-TEL and DEC-TEL are not present in the header); for these
-        # images we replace the RA by the RA-TEL
+        # images we replace the RA and DEC by the RA-REF and DEC-REF
         if tel=='ML1':
             tcorr_radec = Time('2019-02-09T00:00:00', format='isot').mjd
             if (mjd_obs < tcorr_radec and 'RA-TEL' in header.keys() and
                 'DEC-TEL' in header.keys()):
-                ra_deg = header['RA-TEL']
-                dec_deg = header['DEC-TEL']
+                ra_deg = Angle(header['RA-REF'], unit=u.hour).degree
+                dec_deg = Angle(header['DEC-REF'], unit=u.deg).degree
                 edit_head(header, 'RA', value=ra_deg,
-                          comments='[deg] Right ascension of image centre (=RA-TEL)')
+                          comments='[deg] Right ascension of image centre (=RA-REF)')
                 edit_head(header, 'DEC', value=dec_deg,
-                          comments='[deg] Declination of image centre (=DEC-TEL)')
-
+                          comments='[deg] Declination of image centre (=DEC-REF)')
 
         lat = get_par(set_zogy.obs_lat,tel)
         lon = get_par(set_zogy.obs_long,tel)


### PR DESCRIPTION
The RA and DEC correction for the data taken up to 9 Feb 2019 (as the RA and DEC were incorrectly referring to the subsequent image) was in the previous version of the pipeline done with RA-TEL and DEC-TEL. However, these are also incorrect. In this version, it's done with RA-REF and DEC-REF, which are the correct coordinates.