### PR TITLE
Setting NCOSMICS & NSATS default values to None

### DIFF
--- a/Settings/set_qc.py
+++ b/Settings/set_qc.py
@@ -167,7 +167,7 @@ qc_range = {
         
         # cosmics/satellites
         'NCOSMICS': {'default':'None', 'val_type': 'min_max', 'val_range': [ (3,50), (2.5,100), (2,200) ], 'cat_type': 'all', 'comment': '[/s] number of cosmic rays identified'},
-        'NSATS'   : {'default':0, 'val_type': 'min_max', 'val_range': [ (0,1), (2,3), (4,5) ],  'cat_type': 'all', 'comment': 'number of satellite trails identified'},
+        'NSATS'   : {'default':'None', 'val_type': 'min_max', 'val_range': [ (0,1), (2,3), (4,5) ],  'cat_type': 'all', 'comment': 'number of satellite trails identified'},
 
         # SExtractor
         'S-NOBJ'  : {'default':'None', 'val_type': 'min_max', 'val_range': [ (5e3,5e4), (3e3,2e5), (1e3,1e6) ], 'cat_type': 'all', 'comment': 'number of objects detected by SExtractor'},

--- a/blackbox.py
+++ b/blackbox.py
@@ -899,6 +899,7 @@ def blackbox_reduce (filename, telescope, mode, read_path):
         cosmics_processed = False
         data, data_mask = cosmics_corr(data, header, data_mask, header_mask)
     except Exception as e:
+        header['NCOSMICS'] = ('None', '[/s] number of cosmic rays identified')
         q.put(logger.info(traceback.format_exc()))
         q.put(logger.error('exception was raised during [cosmics_corr]: {}'.format(e)))
         log.info(traceback.format_exc())
@@ -923,7 +924,7 @@ def blackbox_reduce (filename, telescope, mode, read_path):
             data_mask = sat_detect(data, header, data_mask, header_mask,
                                    tmp_path)
     except Exception as e:
-        header['NSATS'] = (0, 'number of satellite trails identified')
+        header['NSATS'] = ('None', 'number of satellite trails identified')
         q.put(logger.info(traceback.format_exc()))
         q.put(logger.error('exception was raised during [sat_detect]: {}'.format(e)))
         log.info(traceback.format_exc())


### PR DESCRIPTION
- Setting default of NSATS to None
- Adding a line to set NCOSMICS to None if an error occurs in the cosmic ray detection