### PR TITLE
Bug fix for using image_list

### DIFF
--- a/blackbox.py
+++ b/blackbox.py
@@ -211,8 +211,7 @@ def run_blackbox (telescope=None, mode=None, date=None, read_path=None,
 
         else:
             # use [pool_func] to process list of files
-            for files in lists:
-                result = pool_func (try_blackbox_reduce, files)
+            result = pool_func (try_blackbox_reduce, filenames)
 
 
     elif mode == 'night':


### PR DESCRIPTION
Pool_func takes file list as input (not single file) and "lists" isn't defined, it's supposed to be "filenames" (see l.191).